### PR TITLE
Fix gcc warning: enumeral and non-enumeral type in conditional expression

### DIFF
--- a/TinyGPS.cpp
+++ b/TinyGPS.cpp
@@ -353,7 +353,7 @@ void TinyGPS::get_position(long *latitude, long *longitude, unsigned long *fix_a
   if (latitude) *latitude = _latitude;
   if (longitude) *longitude = _longitude;
   if (fix_age) *fix_age = _last_position_fix == GPS_INVALID_FIX_TIME ? 
-   GPS_INVALID_AGE : millis() - _last_position_fix;
+   (unsigned long) GPS_INVALID_AGE : millis() - _last_position_fix;
 }
 
 // date as ddmmyy, time as hhmmsscc, and age in milliseconds
@@ -362,7 +362,7 @@ void TinyGPS::get_datetime(unsigned long *date, unsigned long *time, unsigned lo
   if (date) *date = _date;
   if (time) *time = _time;
   if (age) *age = _last_time_fix == GPS_INVALID_FIX_TIME ? 
-   GPS_INVALID_AGE : millis() - _last_time_fix;
+   (unsigned long) GPS_INVALID_AGE : millis() - _last_time_fix;
 }
 
 void TinyGPS::f_get_position(float *latitude, float *longitude, unsigned long *fix_age)


### PR DESCRIPTION
Quick fix to remove two warnings when building with "newer" gcc versions.
