### PR TITLE
clear_fix() patch - for when you put the GPS module to sleep

### DIFF
--- a/TinyGPS.cpp
+++ b/TinyGPS.cpp
@@ -57,6 +57,21 @@ TinyGPS::TinyGPS()
 // public methods
 //
 
+void TinyGPS::clear_fix()
+{
+  _time = GPS_INVALID_TIME;
+  _date = GPS_INVALID_DATE;
+  _latitude = GPS_INVALID_ANGLE;
+  _longitude = GPS_INVALID_ANGLE;
+  _altitude = GPS_INVALID_ALTITUDE;
+  _speed = GPS_INVALID_SPEED;
+  _course = GPS_INVALID_ANGLE;
+  _hdop = GPS_INVALID_HDOP;
+  _numsats = GPS_INVALID_SATELLITES;
+  _last_time_fix = GPS_INVALID_FIX_TIME;
+  _last_position_fix = GPS_INVALID_FIX_TIME;
+}
+
 bool TinyGPS::encode(char c)
 {
   bool valid_sentence = false;

--- a/TinyGPS.h
+++ b/TinyGPS.h
@@ -57,6 +57,10 @@ public:
   bool encode(char c); // process one character received from GPS
   TinyGPS &operator << (char c) {encode(c); return *this;}
 
+  // If you put the GPS module to sleep and wake it up, call this
+  // to prevent prevent receiving stale data
+  void clear_fix();
+  
   // lat/long in MILLIONTHs of a degree and age of fix in milliseconds
   // (note: versions 12 and earlier gave lat/long in 100,000ths of a degree.
   void get_position(long *latitude, long *longitude, unsigned long *fix_age = 0);


### PR DESCRIPTION
I've got a project where I put the GPS module to sleep to preserve battery, and then I put the ATMega chip to sleep as well. When it wakes up, get_position() thinks that the fix age has not dramatically increased, because the clock has been stopped while everything was asleep. So I get stale data for a few seconds before the fix age gets long enough that I "notice."

clear_fix() blows away the internal state as if you had created a whole new TinyGPS object.
