### PR TITLE
Add method to expose fix type.

### DIFF
--- a/TinyGPS.cpp
+++ b/TinyGPS.cpp
@@ -36,6 +36,7 @@ TinyGPS::TinyGPS()
   ,  _course(GPS_INVALID_ANGLE)
   ,  _hdop(GPS_INVALID_HDOP)
   ,  _numsats(GPS_INVALID_SATELLITES)
+  ,  _fix_type(GPS_INVALID_FIX_TYPE)
   ,  _last_time_fix(GPS_INVALID_FIX_TIME)
   ,  _last_position_fix(GPS_INVALID_FIX_TIME)
   ,  _parity(0)
@@ -195,6 +196,7 @@ bool TinyGPS::term_complete()
           _longitude = _new_longitude;
           _numsats   = _new_numsats;
           _hdop      = _new_hdop;
+	  _fix_type  = _new_fix_type;
           break;
         }
 
@@ -261,6 +263,7 @@ bool TinyGPS::term_complete()
       _new_date = gpsatol(_term);
       break;
     case COMBINE(_GPS_SENTENCE_GPGGA, 6): // Fix data (GPGGA)
+      _new_fix_type = _term[0];
       _gps_data_good = _term[0] > '0';
       break;
     case COMBINE(_GPS_SENTENCE_GPGGA, 7): // Satellites used (GPGGA)

--- a/TinyGPS.h
+++ b/TinyGPS.h
@@ -48,7 +48,8 @@ public:
     GPS_INVALID_ALTITUDE = 999999999,  GPS_INVALID_DATE = 0,
     GPS_INVALID_TIME = 0xFFFFFFFF,		 GPS_INVALID_SPEED = 999999999, 
     GPS_INVALID_FIX_TIME = 0xFFFFFFFF, GPS_INVALID_SATELLITES = 0xFF,
-    GPS_INVALID_HDOP = 0xFFFFFFFF
+    GPS_INVALID_HDOP = 0xFFFFFFFF,
+    GPS_INVALID_FIX_TYPE = 0xFF
   };
 
   static const float GPS_INVALID_F_ANGLE, GPS_INVALID_F_ALTITUDE, GPS_INVALID_F_SPEED;
@@ -78,6 +79,9 @@ public:
 
   // horizontal dilution of precision in 100ths
   inline unsigned long hdop() { return _hdop; }
+
+  // Fix type, as reported in the GPGGA sentence
+  inline unsigned char fix_type() { return _fix_type; }
 
   void f_get_position(float *latitude, float *longitude, unsigned long *fix_age = 0);
   void crack_datetime(int *year, byte *month, byte *day, 
@@ -112,6 +116,7 @@ private:
   unsigned long  _course, _new_course;
   unsigned long  _hdop, _new_hdop;
   unsigned short _numsats, _new_numsats;
+  unsigned char _fix_type, _new_fix_type;
 
   unsigned long _last_time_fix, _new_time_fix;
   unsigned long _last_position_fix, _new_position_fix;

--- a/examples/test_with_gps_device/test_with_gps_device.ino
+++ b/examples/test_with_gps_device/test_with_gps_device.ino
@@ -15,6 +15,7 @@ static void print_float(float val, float invalid, int len, int prec);
 static void print_int(unsigned long val, unsigned long invalid, int len);
 static void print_date(TinyGPS &gps);
 static void print_str(const char *str, int len);
+static void print_fix_type(unsigned char c, unsigned int len);
 
 void setup()
 {
@@ -23,11 +24,11 @@ void setup()
   Serial.print("Testing TinyGPS library v. "); Serial.println(TinyGPS::library_version());
   Serial.println("by Mikal Hart");
   Serial.println();
-  Serial.println("Sats HDOP Latitude  Longitude  Fix  Date       Time     Date Alt    Course Speed Card  Distance Course Card  Chars Sentences Checksum");
-  Serial.println("          (deg)     (deg)      Age                      Age  (m)    --- from GPS ----  ---- to London  ----  RX    RX        Fail");
-  Serial.println("-------------------------------------------------------------------------------------------------------------------------------------");
+  Serial.println("Sats HDOP Latitude  Longitude  Fix  Fix  Date       Time     Date Alt    Course Speed Card  Distance Course Card  Chars Sentences Checksum");
+  Serial.println("          (deg)     (deg)      Type Age                      Age  (m)    --- from GPS ----  ---- to London  ----  RX    RX        Fail");
+  Serial.println("------------------------------------------------------------------------------------------------------------------------------------------");
 
-  ss.begin(4800);
+  ss.begin(9600);
 }
 
 void loop()
@@ -42,6 +43,7 @@ void loop()
   gps.f_get_position(&flat, &flon, &age);
   print_float(flat, TinyGPS::GPS_INVALID_F_ANGLE, 10, 6);
   print_float(flon, TinyGPS::GPS_INVALID_F_ANGLE, 11, 6);
+  print_fix_type(gps.fix_type(), 5);
   print_int(age, TinyGPS::GPS_INVALID_AGE, 5);
   print_date(gps);
   print_float(gps.f_altitude(), TinyGPS::GPS_INVALID_F_ALTITUDE, 7, 2);
@@ -133,3 +135,26 @@ static void print_str(const char *str, int len)
     Serial.print(i<slen ? str[i] : ' ');
   smartdelay(0);
 }
+
+static void print_fix_type(unsigned char c, unsigned int len)
+{
+  switch(c)
+  {
+    case '1': Serial.print("GPS "); break;
+    case '2': Serial.print("DGPS"); break;
+    case '3': Serial.print("PPS"); break;
+    case '4': Serial.print("RTK "); break;
+    case '5': Serial.print("FRTK"); break;
+    case '6': Serial.print("EST "); break;
+    case '7': Serial.print("MAN "); break;
+    case '8': Serial.print("SIM "); break;
+    default:  Serial.print("*** "); break;
+  }
+  
+  for (int i = 4; i < len; i++)
+  {
+    Serial.print(" ");
+  }
+  smartdelay(0);
+}
+


### PR DESCRIPTION
Add a method to expose fix type from GPS module.

I have an application that needs to distinguish between different fix types; in particular I need to tell whether a fix is GPS (type 1) or Differential GPS (type 2) vs invalid (type 0) or Estimated/dead reckoning (type 6). Added the method to make the fix type available through the TinyGPS API.