### PR TITLE
Add GN* alias terms

### DIFF
--- a/TinyGPS.cpp
+++ b/TinyGPS.cpp
@@ -25,6 +25,8 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 #define _GPRMC_TERM   "GPRMC"
 #define _GPGGA_TERM   "GPGGA"
+#define _GNRMC_TERM   "GNRMC"
+#define _GNGGA_TERM   "GNGGA"
 
 TinyGPS::TinyGPS()
   :  _time(GPS_INVALID_TIME)
@@ -212,9 +214,9 @@ bool TinyGPS::term_complete()
   // the first term determines the sentence type
   if (_term_number == 0)
   {
-    if (!gpsstrcmp(_term, _GPRMC_TERM))
+    if (!gpsstrcmp(_term, _GPRMC_TERM) || !gpsstrcmp(_term, _GNRMC_TERM))
       _sentence_type = _GPS_SENTENCE_GPRMC;
-    else if (!gpsstrcmp(_term, _GPGGA_TERM))
+    else if (!gpsstrcmp(_term, _GPGGA_TERM) || !gpsstrcmp(_term, _GNGGA_TERM))
       _sentence_type = _GPS_SENTENCE_GPGGA;
     else
       _sentence_type = _GPS_SENTENCE_OTHER;


### PR DESCRIPTION
Add GNRMC and GNGGA as aliases for the GPRMC and GPGGA terms. 
A GPS unit I recently obtained used these terms, which apparently refer to GNSS compatibility.  
See e.g. https://community.emlid.com/t/nmea-output-string-has-changed/9515

I'm using TinyGPS instead of TinyGPSPlus because it's fine for me and I had some trouble compiling TinyGPSPlus for my Arduino Nano clone, dunno why.